### PR TITLE
feat: node init as super role if it is a valid validator's delegator 

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/ignite/cli/ignite/pkg/cosmosclient"
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
@@ -37,6 +38,7 @@ type ChainSvc struct {
 	nodeClient       nodetypes.QueryClient
 	didClient        didtypes.QueryClient
 	modelClient      modeltypes.QueryClient
+	stakingClient    stakingtypes.QueryClient
 	listener         *http.HTTP
 	accountRetriever authtypes.AccountRetriever
 	ap               *AddressPool
@@ -67,7 +69,7 @@ type ChainSvcApi interface {
 	QueryMetadata(ctx context.Context, req *types.MetadataProposal, height int64) (*saotypes.QueryMetadataResponse, error)
 	GetMeta(ctx context.Context, dataId string) (*modeltypes.QueryGetMetadataResponse, error)
 	UpdatePermission(ctx context.Context, signer string, proposal *types.PermissionProposal) (string, error)
-	Create(ctx context.Context, creator string) (string, error)
+	Create(ctx context.Context, creator string, validator string) (string, error)
 	Reset(ctx context.Context, creator string, peerInfo string, status uint32, txAddresses []string, description *nodetypes.Description) (string, error)
 	GetNodePeer(ctx context.Context, creator string) (string, error)
 	GetNodeStatus(ctx context.Context, creator string) (uint32, error)
@@ -111,6 +113,7 @@ func NewChainSvc(
 	nodeClient := nodetypes.NewQueryClient(cosmos.Context())
 	didClient := didtypes.NewQueryClient(cosmos.Context())
 	modelClient := modeltypes.NewQueryClient(cosmos.Context())
+	stakingClient := stakingtypes.NewQueryClient(cosmos.Context())
 
 	log.Debugf("initialize chain listener")
 	http, err := http.New(chainAddress, wsEndpoint)
@@ -126,6 +129,7 @@ func NewChainSvc(
 		nodeClient:       nodeClient,
 		didClient:        didClient,
 		modelClient:      modelClient,
+		stakingClient:    stakingClient,
 		listener:         http,
 		accountRetriever: accountRetriever,
 		broadcastChanMap: make(map[string]chan BroadcastTxJob),

--- a/types/errors.go
+++ b/types/errors.go
@@ -64,6 +64,7 @@ var (
 	ErrInconsistentAddress = errors.Register(ModuleChain, 11027, "inconsistent address")
 
 	ErrGenerateMnemonicFailed = errors.Register(ModuleChain, 11028, "failed to generate mnemonic")
+	ErrInvalidValidator       = errors.Register(ModuleChain, 11029, "invalid validator")
 )
 
 var (


### PR DESCRIPTION
if an account delegates to a validator and its share > 10%, the same account can apply as a super storage node to have higher possibility to accept orders. 
during init,  if validator is active(unjailed and bond status) and delegtion share percentage > 10%, node init will succeed and its role is 1 - 'super' in concensus.
if not, node initialize will fail.

If validator is inactive in a later period, this node will downgrade to a normal sp to accept orders.